### PR TITLE
Improve team selector and stream layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             border-radius: 0.5rem;
             transition: transform 0.2s, box-shadow 0.2s;
         }
-        .team-btn img { height: 80px; }
+        .team-btn img { height: 100px; }
         .team-btn.selected {
             transform: scale(1.05);
             box-shadow: 0 0 0 4px rgb(139 92 246);
@@ -56,7 +56,7 @@
     <div id="bg-left"></div>
     <div id="bg-right"></div>
     <section class="max-w-6xl mx-auto p-4">
-        <div id="teamSelector" class="flex overflow-x-auto whitespace-nowrap gap-4 mb-6 px-2"></div>
+        <div id="teamSelector" class="flex whitespace-nowrap gap-4 mb-6 px-2"></div>
         <div id="match" class="flex flex-col md:flex-row items-start justify-center gap-6"></div>
     </section>
     <script>
@@ -266,9 +266,9 @@
             const data = teams[team];
             const card = document.createElement('div');
             card.className = 'team-card';
-            const streams = data.streams.map(s =>
-                <iframe class="w-full h-56" src="https://player.twitch.tv/?channel=${encodeURIComponent(s.url.split('/').pop())}&parent=${window.location.hostname}" allowfullscreen></iframe>
-            ).join('');
+            const streams = `<div class="flex flex-row flex-wrap gap-4 overflow-x-auto">${data.streams.map(s =>
+                `<iframe class="w-60 h-56" src="https://player.twitch.tv/?channel=${encodeURIComponent(s.url.split('/').pop())}&parent=${window.location.hostname}" allowfullscreen></iframe>`
+            ).join('')}</div>`;
             const links = data.streams.map(s => <a href="${s.url}" target="_blank" class="text-violet-300 underline mr-2">${s.name}</a>).join(' ');
             card.innerHTML = 
                 <img src="${data.logo}" alt="${team} logo" class="mb-4">


### PR DESCRIPTION
## Summary
- stop scrolling for the team selector row
- enlarge team logos for easier selection
- arrange match streams horizontally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d25c8a248832aadddca7633f8bbc7